### PR TITLE
prepare for garnix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,13 @@
     };
 
   nixConfig = {
-    extra-substituters = [ "https://cache.iog.io" ];
+    extra-substituters = [
+      "https://cache.iog.io"
+      "https://cache.garnix.io"
+    ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
     ];
     accept-flake-config = true;
     allow-import-from-derivation = true;

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,3 @@
+builds:
+  include:
+  - 'checks.*.*'

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -4,6 +4,22 @@ let
 in
 [
   (
-    project.flake
+    project.flake // {
+      checks =
+        let
+          # https://github.com/numtide/flake-utils/issues/121#issuecomment-2589899217
+          recurseIntoDeepAttrs = attrs:
+            lib.recurseIntoAttrs
+              (lib.mapAttrs
+                (_: v:
+                  if builtins.typeOf v == "set" && !lib.isDerivation v
+                  then recurseIntoDeepAttrs v
+                  else v
+                )
+                attrs
+              );
+        in
+        inputs.iogx.inputs.flake-utils.lib.flattenTree (recurseIntoDeepAttrs project.flake.hydraJobs);
+    }
   )
 ]


### PR DESCRIPTION
- Add garnix cache to the flake nix config.
- Add `garnix.yaml` that builds only `.#checks`.
- Adjust the flake outputs to make garnix build everything that Hydra did.

Garnix does not build the `hydraJobs` output
so move them all into the `checks` output,
adhering to the flake output schema
because garnix does not build nested attrsets.

Note that this replaces the layout of the `checks` output
but it should still include all the checks that it had previously.
So no checks are removed, they just have a different name.
I hope that's ok and no checks are referred to by name somewhere.